### PR TITLE
Adding CSS classes make selecting dropdowns easier

### DIFF
--- a/addon/components/device-selection/template.hbs
+++ b/addon/components/device-selection/template.hbs
@@ -15,7 +15,7 @@
                         {{#x-select id=(concat elementId '-camera-select')
                            value=selectedCameraId
                            action="changeCamera"
-                           class="form-control"}}
+                           class="form-control camera-select"}}
                             {{#each webrtc.cameraList as |camera|}}
                                 {{#x-option value=camera.deviceId}}{{camera.label}}{{/x-option}}
                             {{/each}}
@@ -37,7 +37,7 @@
                            id=(concat elementId '-filter-select')
                            value=selectedFilter
                            action="(action (mut selectedFilter))"
-                           class="form-control"}}
+                           class="form-control filter-select"}}
                             {{#each advancedOptions as |option|}}
                                 {{#x-option value=option}}{{option}}{{/x-option}}
                             {{/each}}
@@ -62,7 +62,7 @@
                            id=(concat elementId '-microphone-select')
                            value=selectedMicrophoneId
                            action="changeMicrophone"
-                           class="form-control"}}
+                           class="form-control microphone-select"}}
                             {{#each webrtc.microphoneList as |microphone|}}
                                 {{#x-option value=microphone.deviceId}}{{microphone.label}}{{/x-option}}
                             {{/each}}
@@ -95,7 +95,7 @@
                        id=(concat elementId '-speakers-select')
                        value=selectedOutputDeviceId
                        action="changeOutputDevice"
-                       class="form-control"}}
+                       class="form-control speakers-select"}}
                         {{#each webrtc.outputDeviceList as |outputDevice|}}
                             {{#x-option value=outputDevice.deviceId}}{{outputDevice.label}}{{/x-option}}
                         {{/each}}
@@ -118,7 +118,7 @@
                        id=(concat elementId '-resolution-select')
                        value=selectedResolutionId
                        action="changeResolution"
-                       class="form-control"}}
+                       class="form-control resolution-select"}}
                         {{#each webrtc.resolutionList as |resolution|}}
                             {{#x-option value=resolution.presetId}}{{resolution.label}}{{/x-option}}
                         {{/each}}


### PR DESCRIPTION
This PR adds classes to the dropdown select elements to aid other software that uses selectors to interact with these elements (like webdriver)