### PR TITLE
Check application environment for developing addon state

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,10 +7,12 @@ const json = require('broccoli-json-module');
 module.exports = {
   name: 'webrtc-devices',
   isDevelopingAddon: function () {
-    return true;
+    return this.app && this.app.env === 'development';
   },
   included: function (app) {
     this._super.included(app);
+
+    this.app = app;
 
     this.translation = new WatchedDir('translations');
 


### PR DESCRIPTION
While the addon is in development mode, JSCS/JSHint tests run in the consuming application. This just makes sure that the addon is not in development mode during ember test runs of the consuming application.