### PR TITLE
Cancel scheduled timer on destroy for test cleanup

### DIFF
--- a/addon/mixins/device-enumeration.js
+++ b/addon/mixins/device-enumeration.js
@@ -71,16 +71,28 @@ export default Mixin.create({
 
   canShareScreen: false,
 
+  enumerationTimer: null,
+
   // Returns a promise which resolves when all devices have been enumerated and loaded
   init () {
     this._super(...arguments);
-    run.next(this, function () {
+    const timer = run.next(this, function () {
       this.enumerateDevices();
       this.enumerateResolutions();
     });
+    this.set('enumerationTimer', timer);
     this.set('canShareScreen', webrtcsupport.supportScreenSharing);
 
     this.lookup = this.lookup || ((key) => key);
+  },
+
+  willDestroy () {
+    const timer = this.get('enumerationTimer');
+    if (timer) {
+      run.cancel(timer);
+    }
+
+    this._super(...arguments);
   },
 
   updateDefaultDevices (/* devices */) {

--- a/tests/integration/components/device-selection/component-test.js
+++ b/tests/integration/components/device-selection/component-test.js
@@ -99,36 +99,45 @@ test('it shows a message iff the browser cannot enumerate devices', function (as
 });
 
 test('it shows a camera select and resolution select iff there are cameras, and video is true, and there are resolutions', function (assert) {
-  return Ember.run(this, function () {
+  Ember.run(this, function () {
     this.get('webrtc.cameraList').pushObjects(mockDevices);
     this.get('webrtc.resolutionList').pushObjects(mockResolutions);
     this.renderDefault();
-    assert.equal(this.$('select').length, 2);
+  });
 
+  assert.equal(this.$('select').length, 2);
+
+  Ember.run(this, function () {
     this.get('webrtc.cameraList').clear();
     this.renderDefault();
-    assert.equal(this.$('select').length, 0);
+  });
 
+  assert.equal(this.$('select').length, 0);
+
+  Ember.run(this, function () {
     this.get('webrtc.cameraList').pushObjects(mockDevices);
     this.set('video', false);
     this.renderDefault();
-
-    assert.equal(this.$('select').length, 0);
   });
+
+  assert.equal(this.$('select').length, 0);
 });
 
 test('it shows microphone select iff there are microphones and audio is true', function (assert) {
-  return Ember.run(this, function () {
+  Ember.run(this, function () {
     this.get('webrtc.microphoneList').pushObjects(mockDevices);
     this.renderDefault();
-    assert.equal(this.$('select').length, 1);
+  });
 
+  assert.equal(this.$('select').length, 1);
+
+  Ember.run(this, function () {
     this.get('webrtc.microphoneList').pushObjects(mockDevices);
     this.set('audio', false);
     this.renderDefault();
-
-    assert.equal(this.$('select').length, 0);
   });
+
+  assert.equal(this.$('select').length, 0);
 });
 
 test('it shows a troubleshoot button if an openTroubleshoot action is provided', function (assert) {


### PR DESCRIPTION
This stores the timer and will cancel it when consumers are being cleaned up. This fixes intermittent issues with consumers throwing errors during tests (occurs randomly).

Note: I was also getting inconsistent results in the test and moved only the asynchronous run-loop portions of the code inside the testing run-loop and left the asserts outside of that.