### PR TITLE
Separate video call capable from call capable

### DIFF
--- a/addon/mixins/device-enumeration.js
+++ b/addon/mixins/device-enumeration.js
@@ -68,18 +68,20 @@ export default Mixin.create({
     return !this.get('canShareAudio') && !this.get('canShareVideo');
   }),
 
-  callCapable: computed(function () {
+  callCapable: computed.and('audioCallCapable', 'videoCallCapable'),
+
+  audioCallCapable: computed('canShareAudio', function () {
     const PC = window.RTCPeerConnection;
     const gUM = window.navigator && window.navigator.mediaDevices && window.navigator.mediaDevices.getUserMedia;
     const supportWebAudio = window.AudioContext && window.AudioContext.prototype.createMediaStreamSource;
     const support = !!(PC && gUM && supportWebAudio);
 
-    return support;
+    return support && this.get('canShareAudio');
   }),
 
-  videoCallCapable: computed('noVideoHardware', 'callCapable', function () {
-    const callCapable = this.get('callCapable');
-    if (!callCapable) {
+  videoCallCapable: computed('noVideoHardware', 'audio', function () {
+    const audioCallCapable = this.get('audioCallCapable');
+    if (!audioCallCapable) {
       return false;
     }
 
@@ -94,7 +96,7 @@ export default Mixin.create({
   outputDeviceList: Ember.A(),
   resolutionList: Ember.A(),
 
-  canShareScreen: computed.reads('videoCallCapable'),
+  canShareScreen: computed.reads('callCapable'),
 
   enumerationTimer: null,
 

--- a/addon/mixins/device-enumeration.js
+++ b/addon/mixins/device-enumeration.js
@@ -68,25 +68,33 @@ export default Mixin.create({
     return !this.get('canShareAudio') && !this.get('canShareVideo');
   }),
 
-  callCapable: computed('noVideoHardware', function () {
-    const videoEl = document.createElement('video');
+  callCapable: computed(function () {
     const PC = window.RTCPeerConnection;
     const gUM = window.navigator && window.navigator.mediaDevices && window.navigator.mediaDevices.getUserMedia;
-    const supportVp8 = videoEl && videoEl.canPlayType && videoEl.canPlayType('video/webm; codecs="vp8", vorbis') === 'probably';
     const supportWebAudio = window.AudioContext && window.AudioContext.prototype.createMediaStreamSource;
-    const support = !!(PC && gUM && supportVp8 && supportWebAudio);
+    const support = !!(PC && gUM && supportWebAudio);
 
-    if (!support) {
+    return support;
+  }),
+
+  videoCallCapable: computed('noVideoHardware', 'callCapable', function () {
+    const callCapable = this.get('callCapable');
+    if (!callCapable) {
       return false;
     }
 
+    const videoEl = document.createElement('video');
+    const supportVp8 = videoEl && videoEl.canPlayType && videoEl.canPlayType('video/webm; codecs="vp8", vorbis') === 'probably';
+    if (!supportVp8) {
+      return false;
+    }
     return !this.get('noVideoHardware');
   }),
 
   outputDeviceList: Ember.A(),
   resolutionList: Ember.A(),
 
-  canShareScreen: computed.reads('callCapable'),
+  canShareScreen: computed.reads('videoCallCapable'),
 
   enumerationTimer: null,
 


### PR DESCRIPTION
This is so that we can distinctly differentiate for browsers that support audio calls but not video (ms Edge)