### PR TITLE
[PCDWEBK-4120] Add play icon to webrtc settings

### DIFF
--- a/addon/components/device-selection/template.hbs
+++ b/addon/components/device-selection/template.hbs
@@ -134,6 +134,7 @@
         </div>
         <div class= "entry-row audio-text">
             <a href="#" class="btn btn-link play-sound-btn" {{action "playTestSound"}} title="{{t "webrtcDevices.audioDestinationTooltip"}}">
+                <svg class="svg-icon"><use xlink:href="#icon-play"></use></svg>
                 <span class="preview-audio-text">
                     {{t "webrtcDevices.playAudio"}}
                 </span>


### PR DESCRIPTION
RELATED PR: https://bitbucket.org/inindca/web-directory/pull-requests/6163/add-fixed-width-to-speaker-and-microphone/diff

## Before
<img width="1440" alt="screen shot 2017-05-31 at 11 09 52 am" src="https://cloud.githubusercontent.com/assets/485903/26652794/0d71606e-461f-11e7-8683-4093093c7142.png">

## After
<img width="1440" alt="screen shot 2017-05-31 at 4 32 32 pm" src="https://cloud.githubusercontent.com/assets/485903/26652768/f620d958-461e-11e7-9aad-781f95fae8b2.png">

