### PR TITLE
Added component property to hide input device selection

### DIFF
--- a/addon/components/device-selection/component.js
+++ b/addon/components/device-selection/component.js
@@ -20,6 +20,7 @@ export default Component.extend(/* LoggerMixin, */{
   video: true,
   troubleshoot: true,
   outputDevice: true,
+  inputDevice: true,
   resolution: true,
 
   webrtc: inject.service(),
@@ -75,6 +76,7 @@ export default Component.extend(/* LoggerMixin, */{
     return this.get('troubleshoot') && typeof this.attrs.openTroubleshoot === 'function';
   }),
 
+  showInputDevicePicker: computed.and('webrtc.microphoneList.length', 'inputDevice', 'audio'),
   showOutputDevicePicker: computed.and('outputDevice', 'audio'),
   showResolutionPicker: computed.and('webrtc.resolutionList.length', 'webrtc.cameraList.length', 'video', 'resolution'),
 

--- a/addon/components/device-selection/template.hbs
+++ b/addon/components/device-selection/template.hbs
@@ -46,7 +46,7 @@
                 </div>
             {{/if}}
         {{/if}}
-        {{#if (and webrtc.microphoneList.length audio)}}
+        {{#if showInputDevicePicker}}
             <div class="entry-row">
                 <div class="entry-label">
                     <label for="{{concat elementId '-microphone-select'}}">


### PR DESCRIPTION
As part of PCM-666 the sound preferences menu does not need to show the input section of the device selector, in fact it would probably just generate confusion since the volume sliders in the sound preferences menu are only for output devices.

This change just introduces a parameter on the component to allow the component user to show/hide the input and output device selectors independent of one another